### PR TITLE
Makefile: remove redundant processor tuning flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -403,7 +403,7 @@ KBUILD_CFLAGS   := -Wall -Wundef -Wstrict-prototypes -Wno-trigraphs \
 		   -fno-strict-aliasing -fno-common \
 		   -Werror-implicit-function-declaration \
 		   -Wno-format-security \
-		   -mcpu=cortex-a57.cortex-a53 -mtune=cortex-a57.cortex-a53 \
+		   -mcpu=cortex-a57.cortex-a53 \
 		   -std=gnu89
 		   
 # arter97's optimizations


### PR DESCRIPTION
The -mcpu flag specifies the target for both assembly code instructions (-march) and performance tuning (-mtune). Including another -mtune flag targeting the same ARM processor is not needed.

Documentation found at https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html.